### PR TITLE
Add CI for Wake typechecking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Wake 0.18 typecheck
+    runs-on: ubuntu-latest
+    env:
+      # $WIT_WORKSPACE path is relative to $GITHUB_WORKSPACE
+      WIT_WORKSPACE: wit-workspace
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: wit-packages/scribble
+        # Fetch all history and tags
+        fetch-depth: 0
+
+    - name: 'Wit Init'
+      uses: sifive/wit/actions/wit@v0.13.1
+      with:
+        command: init
+        arguments: |
+          ${{ env.WIT_WORKSPACE }}
+          -a ./wit-packages/scribble
+        force_github_https: true
+
+    - name: Run wake typecheck
+      working-directory: ${{ env.WIT_WORKSPACE }}
+      run: |
+        set -euxo pipefail
+
+        # Take back ownership of wit workspace, since it was created while
+        # under a Docker container and permissions default to root.
+        uid=$(id -u)
+        gid=$(id -g)
+        sudo chown -R "$uid:$gid" .
+
+        # Install Wake
+        curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.18.1/ubuntu-18-04-wake_0.18.1-1_amd64.deb && \
+            sudo dpkg -i /tmp/wake.deb && \
+            rm /tmp/wake.deb
+
+        # Initialize Wake workspace
+        wake --init .
+
+        # Run a dummy target, which still triggers a compilation of Wake code.
+        wake -x Unit

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,7 @@
 [
     {
-        "commit": "96cdaf23a35173c156fe7a986c33d34c70fc81fe",
+        "//": "v0.2.2",
+        "commit": "29770efe2cf4e72edfb05da1baa1a08c5638f839",
         "name": "api-languages-sifive",
         "source": "git@github.com:sifive/api-languages-sifive.git"
     }


### PR DESCRIPTION
This adds CI to this repo so that we check that `wake -x Unit` passes a type check. Coincidentally, this actually failed the wake 0.18 type check because it was pointing to too old of a version of api-languages-sifive, so I've also bumped api-languages-sifive to get wake 0.18-compatibility for that package as well.